### PR TITLE
Fix mod for 0.11.5, Add GetEquipSlotItem and similar mod.Calls

### DIFF
--- a/GlobalWingItem.cs
+++ b/GlobalWingItem.cs
@@ -19,7 +19,7 @@ namespace WingSlot {
                 return;
             }
 
-            WingSlotPlayer mp = player.GetModPlayer<WingSlotPlayer>(mod);
+            WingSlotPlayer mp = player.GetModPlayer<WingSlotPlayer>();
             mp.EquipWings(KeyboardUtils.HeldDown(Keys.LeftShift), item);
         }
     }

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -1,0 +1,20 @@
+{
+  "profiles": {
+    "Terraria": {
+      "commandName": "Executable",
+      "executablePath": "$(tMLPath)",
+      "workingDirectory": "$(TerrariaSteamPath)"
+    },
+    "TerrariaFast": {
+      "commandName": "Executable",
+      "executablePath": "$(tMLPath)",
+      "commandLineArgs": "-skipselect",
+      "workingDirectory": "$(TerrariaSteamPath)"
+    },
+    "TerrariaServer": {
+      "commandName": "Executable",
+      "executablePath": "$(tMLServerPath)",
+      "workingDirectory": "$(TerrariaSteamPath)"
+    }
+  }
+}

--- a/WingSlot.cs
+++ b/WingSlot.cs
@@ -38,27 +38,63 @@ namespace WingSlot {
         }
 
         public override object Call(params object[] args) {
-            string keyword = args[0] as string;
-            Func<bool> func = args[1] as Func<bool>;
+            try {
+                string keyword = args[0] as string;
+                if(string.IsNullOrEmpty(keyword)) {
+                    return null;
+                }
+                keyword = keyword.ToLower();
 
-            if(string.IsNullOrEmpty(keyword) || func == null) {
+                switch(keyword) {
+                    case "add":
+                    case "remove":
+                        //wingSlot.Call(/* "add" or "remove" */, /* func<bool> returns true to cancel/false to continue normal execution */);
+                        //These two should be called in PostSetupContent
+                        Func<bool> func = args[1] as Func<bool>;
+                        if(func == null) return null;
+                        if(keyword == "add") {
+                            RightClickOverrides.Add(func);
+                        }
+                        else if(keyword == "remove") {
+                            RightClickOverrides.Remove(func);
+                        }
+                        break;
+                    case "getequipslotitem":
+                    case "getvanityslotitem":
+                    case "getvisibleitem":
+                        //Can't use these three in PostSetupContent because EquipSlot is a field in WingSlotPlayer, but that's not initialized yet
+                        //Hence why I couldn't make some sort of delegate as an argument that assigned it
+
+                        //Item wingItem = (Item)wingSlot.Call(/* "getequipslotitem" or "getvanityslotitem" or "getdisplayeditem"*/);
+                        //These three should be called on demand
+                        WingSlotPlayer wsp = Main.LocalPlayer.GetModPlayer<WingSlotPlayer>();
+                        if(keyword == "getequipslotitem") {
+                            return wsp.EquipSlot.Item;
+                        }
+                        else if(keyword == "getvanityslotitem") {
+                            return wsp.VanitySlot.Item;
+                        }
+                        //Returns the item that is responsible for the wings to display on the player (at all times or during flight)
+                        else if(keyword == "getvisibleitem") {
+                            if(wsp.VanitySlot.Item.wingSlot > 0) {
+                                return wsp.VanitySlot.Item;
+                            }
+                            else {
+                                return wsp.EquipSlot.Item;
+                            }
+                        }
+                        break;
+                }
+            }
+            catch {
                 return null;
-            }
-
-            keyword = keyword.ToLower();
-
-            if(keyword == "add") {
-                RightClickOverrides.Add(func);
-            }
-            else if(keyword == "remove") {
-                RightClickOverrides.Remove(func);
             }
 
             return null;
         }
 
         public override void PostDrawInterface(SpriteBatch spriteBatch) {
-            WingSlotPlayer wsp = Main.player[Main.myPlayer].GetModPlayer<WingSlotPlayer>(this);
+            WingSlotPlayer wsp = Main.LocalPlayer.GetModPlayer<WingSlotPlayer>();
             wsp.Draw(spriteBatch);
         }
 

--- a/WingSlot.cs
+++ b/WingSlot.cs
@@ -65,9 +65,10 @@ namespace WingSlot {
                         //Can't use these three in PostSetupContent because EquipSlot is a field in WingSlotPlayer, but that's not initialized yet
                         //Hence why I couldn't make some sort of delegate as an argument that assigned it
 
-                        //Item wingItem = (Item)wingSlot.Call(/* "getequipslotitem" or "getvanityslotitem" or "getdisplayeditem"*/);
+                        //Item wingItem = (Item)wingSlot.Call(/* "getequipslotitem" or "getvanityslotitem" or "getdisplayeditem"*/, player.whoAmI);
                         //These three should be called on demand
-                        WingSlotPlayer wsp = Main.LocalPlayer.GetModPlayer<WingSlotPlayer>();
+                        int whoAmI = Convert.ToInt32(args[1]);
+                        WingSlotPlayer wsp = Main.player[whoAmI].GetModPlayer<WingSlotPlayer>();
                         if(keyword == "getequipslotitem") {
                             return wsp.EquipSlot.Item;
                         }


### PR DESCRIPTION
This PR provides three new mod.Calls getequipslotitem, getvanityslotitem and getvisibleitem, with each returning an `Item`. Called on demand, not in PostSetupContent because WingSlotPlayer isn't initialized yet.
* When needing the item inside the slot for certain purposes, for example when iterating through the accessory/equip slots.

Example:
```cs
Item wingItem = null;
if (ModLoader.GetMod("WingSlot") is Mod wingSlot && wingSlot != null) {
    wingItem = (Item)wingSlot.Call("getvisibleitem", player.whoAmI);
}
for (int j = 3; j < 8 + player.extraAccessorySlots; j++)
{
    Item item = player.armor[j];
    if (!item.IsAir && item.wingSlot > 0)
    {
        wingItem = item;
    }
}
if (wingItem != null) //stuff
```